### PR TITLE
Finalize access to underlying http request for cookies

### DIFF
--- a/opendolphin/js/dolphin/DolphinBuilder.ts
+++ b/opendolphin/js/dolphin/DolphinBuilder.ts
@@ -13,6 +13,7 @@ export default class DolphinBuilder {
     maxBatchSize_ :number = 50;
     supportCORS_: boolean = false;
     errorHandler_:(any) => void;
+    headersInfo_: Object;
 
     constructor(){
     }
@@ -41,12 +42,16 @@ export default class DolphinBuilder {
         this.errorHandler_ = errorHandler;
         return this;
     }
+    public headersInfo(headersInfo:(Object) => void):DolphinBuilder {
+        this.headersInfo_ = headersInfo;
+        return this;
+    }
     public build():ClientDolphin {
         console.log("OpenDolphin js found");
         var clientDolphin = new ClientDolphin();
         var transmitter;
         if (this.url_ != null && this.url_.length > 0) {
-            transmitter = new HttpTransmitter(this.url_, this.reset_, "UTF-8", this.errorHandler_, this.supportCORS_);
+            transmitter = new HttpTransmitter(this.url_, this.reset_, "UTF-8", this.errorHandler_, this.supportCORS_, this.headersInfo_);
         } else {
             transmitter = new NoTransmitter();
         }

--- a/src/dolphin.js
+++ b/src/dolphin.js
@@ -31,18 +31,26 @@ var ControllerManager = require('./controllermanager.js').ControllerManager;
 var ClientContext = require('./clientcontext.js').ClientContext;
 var HttpTransmitter = require('./httpTransmitter.es6').default;
 
-exports.connect = function(url, config) {
+exports.connect = function (url, config) {
     checkMethod('connect(url, config)');
     checkParam(url, 'url');
 
     var builder = OpenDolphin.makeDolphin().url(url).reset(false).slackMS(4).supportCORS(true).maxBatchSize(Number.MAX_SAFE_INTEGER);
-    if (exists(config) && exists(config.errorHandler)) {
-        builder.errorHandler(config.errorHandler);
+    if (exists(config)) {
+        if (exists(config.errorHandler)) {
+            builder.errorHandler(config.errorHandler);
+        }
+        if (exists(config.headersInfo) &&  Object.keys(config.headersInfo ).length > 0) {
+           builder.headersInfo(config.headersInfo);
+        }
     }
+
     var dolphin = builder.build();
 
-    var transmitter = new HttpTransmitter(url);
-    transmitter.on('error', function(error) { clientContext.emit('error', error); });
+    var transmitter = new HttpTransmitter(url, config.headersInfo);
+    transmitter.on('error', function (error) {
+        clientContext.emit('error', error);
+    });
     dolphin.clientConnector.transmitter = transmitter;
 
     var classRepository = new ClassRepository(dolphin);

--- a/src/dolphin.js
+++ b/src/dolphin.js
@@ -47,7 +47,7 @@ exports.connect = function (url, config) {
 
     var dolphin = builder.build();
 
-    var transmitter = new HttpTransmitter(url, config.headersInfo);
+    var transmitter = new HttpTransmitter(url, exists(config)?config.headersInfo : null);
     transmitter.on('error', function (error) {
         clientContext.emit('error', error);
     });

--- a/src/httpTransmitter.es6
+++ b/src/httpTransmitter.es6
@@ -30,15 +30,15 @@ const CLIENT_ID_HTTP_HEADER_NAME = DOLPHIN_PLATFORM_PREFIX + 'dolphinClientId';
 
 export default class HttpTransmitter {
 
-    constructor(url) {
+    constructor(url, headersInfo) {
         this.url = url;
+        this.headersInfo = headersInfo;
     }
 
     send(commands) {
         return new Promise((resolve, reject) => {
             const http = new XMLHttpRequest();
             http.withCredentials = true;
-
             http.onerror = (error) => reject(new DolphinRemotingError('HttpTransmitter: Network error', error));
             http.onreadystatechange = () => {
                 if (http.readyState === FINISHED){
@@ -72,6 +72,14 @@ export default class HttpTransmitter {
             http.open('POST', this.url);
             if (exists(this.clientId)) {
                 http.setRequestHeader(CLIENT_ID_HTTP_HEADER_NAME, this.clientId);
+            }
+
+            if (exists(this.headersInfo)) {
+                for (var i in this.headersInfo) {
+                    if (this.headersInfo.hasOwnProperty(i)) {
+                        http.setRequestHeader(i, this.headersInfo[i]);
+                    }
+                }
             }
             http.send(encode(commands));
         });


### PR DESCRIPTION
Handle extra header passed with config 

- headers Info can be passed with config to dolphin connect()
- it should be a simple json object with key-value pair
- change made to add headers to transmitter

Allow required headers in **CORS** from server what you want to send from client...for example -
resp.setHeader("Access-Control-Allow-Headers", "x-requested-with, Content-Type, origin, authorization, accept, client-security-token");